### PR TITLE
fix: fix bio layout

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -10,9 +10,9 @@ import { Icon } from 'astro-icon/components';
         <a href="/">CHAI SOLUTIONS</a>
       </div>
       <div class="other-link-box">
-        <a class="other-link" href="#about">ABOUT</a>
-        <a class="other-link" href="#about">TEAM</a>
-        <a class="other-link" href="#contact">CONTACT</a>
+        <a class="other-link" href="/#about">ABOUT</a>
+        <a class="other-link" href="/#team">TEAM</a>
+        <a class="other-link" href="/#contact">CONTACT</a>
       </div>
     </div>
     <div>

--- a/src/layouts/BioLayout.astro
+++ b/src/layouts/BioLayout.astro
@@ -16,10 +16,16 @@ if (image && !imageAlt) {
 ---
 
 <MainLayout title={name}>
-  <h1>{name}</h1>
-  <h2>{role}</h2>
-  {image ? <img class="provided-image" src={image} alt={imageAlt!} /> : null}
-  <slot />
+  <div class="panel-content-wrapper">
+    <h1>{name}</h1>
+    <h2>{role}</h2>
+    {
+      image ?
+        <img class="provided-image" src={`${image}`} alt={imageAlt!} />
+      : null
+    }
+    <slot />
+  </div>
 </MainLayout>
 
 <style>

--- a/src/layouts/BioLayout.astro
+++ b/src/layouts/BioLayout.astro
@@ -21,7 +21,7 @@ if (image && !imageAlt) {
     <h2>{role}</h2>
     {
       image ?
-        <img class="provided-image" src={`${image}`} alt={imageAlt!} />
+        <img src={`/${image}`} alt={imageAlt!} class="provided-image" />
       : null
     }
     <slot />

--- a/src/pages/thamizarasu.astro
+++ b/src/pages/thamizarasu.astro
@@ -8,19 +8,22 @@ import BioLayout from '@layouts/BioLayout.astro';
   image="DoctorLegend.jpg"
   imageAlt="Thamizarasu Sankara's default profile image"
 >
-  <p>Philliphians 4:13: "I can do all things through Christ who strengthens me."</p>
-
   <p>
-    What's up! My name is Thamizarasu Sankara, but you guys can call me Tamil. 
-    I am a senior at SF State. I'm majoring in Computer Science. 
-    Fun fact...my name is also the language I speak at home. 
-    Also the state of India I'm from is Tamil Nadu.
+    Philliphians 4:13: "I can do all things through Christ who strengthens me."
   </p>
 
   <p>
-    I also love music; I been playing the piano for about 9 years, and recently got into music production. 
-    I'm a multisport athlete and compete hard in any sport.
-    I mainly love watching football and basketball. (DubNation and 49ers Faithful)
-    If you guys ever wanna collaborate with me on a project here's my GitHub: thamizarasus
+    What's up! My name is Thamizarasu Sankara, but you guys can call me Tamil. I
+    am a senior at SF State. I'm majoring in Computer Science. Fun fact...my
+    name is also the language I speak at home. Also the state of India I'm from
+    is Tamil Nadu.
+  </p>
+
+  <p>
+    I also love music; I been playing the piano for about 9 years, and recently
+    got into music production. I'm a multisport athlete and compete hard in any
+    sport. I mainly love watching football and basketball. (DubNation and 49ers
+    Faithful) If you guys ever wanna collaborate with me on a project here's my
+    GitHub: thamizarasus
   </p>
 </BioLayout>


### PR DESCRIPTION
The bio layout had some peculiarities.

The content on the page itself was not limited to the max content width using the `panel-content-wrapper` class, so I did that.

The links themselves were not resolving properly, so I had to wrap it into a raw string to make it work properly. Let's hope this works on Netlify, because it seems to work in `astro build` invocations.

Lastly, the header links now always redirect to the home page before going to the ID links.